### PR TITLE
Implement automated docker image deployment to dockerhub

### DIFF
--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -16,7 +16,7 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     # only run if we've specified image tag to push to
-    if: ${{ vars.DOCKERHUB_IMAGE_NAME !== '' ||  vars.GHCR_IMAGE_NAME !== '' }}
+    if: ${{ vars.DOCKERHUB_IMAGE_NAME != '' ||  vars.GHCR_IMAGE_NAME != '' }}
     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
       packages: write
@@ -33,7 +33,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
-        if: ${{ github.event_name != 'pull_request' && vars.GHCR_IMAGE_NAME !== '' }}
+        if: ${{ github.event_name != 'pull_request' && vars.GHCR_IMAGE_NAME != '' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -15,6 +15,8 @@ jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    # only run if we've specified image tag to push to
+    if: ${{ vars.DOCKERHUB_IMAGE_NAME !== '' ||  vars.GHCR_IMAGE_NAME !== '' }}
     # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
       packages: write
@@ -30,21 +32,21 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-#      - name: Login to GitHub Container Registry
-#        if: github.event_name != 'pull_request'
-#        uses: docker/login-action@v2
-#        with:
-#          registry: ghcr.io
-#          username: ${{ github.repository_owner }}
-#          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' && vars.GHCR_IMAGE_NAME !== '' }}
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v3
         with:
           images: |
-            holaflenain/stable-diffusion
-#            ghcr.io/grokuku/stable-diffusion
+            ${{ vars.DOCKERHUB_IMAGE_NAME }}
+            ${{ vars.GHCR_IMAGE_NAME }}
           # generate Docker tags based on the following events/attributes
           tags: |
             type=raw,value=latest,enable=${{ endsWith(github.ref, 'main') }}

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -1,0 +1,69 @@
+name: Publish Docker image to Dockerhub and GHCR
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'test'
+    tags:
+      - '*.*.*'
+    # don't trigger if just updating docs
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+#      - name: Login to GitHub Container Registry
+#        if: github.event_name != 'pull_request'
+#        uses: docker/login-action@v2
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.repository_owner }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            holaflenain/stable-diffusion
+#            ghcr.io/grokuku/stable-diffusion
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=raw,value=latest,enable=${{ endsWith(github.ref, 'main') }}
+            type=ref,event=branch,enable=${{ !endsWith(github.ref, 'main') }}
+            type=semver,pattern={{version}}
+          flavor: |
+            latest=false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' && !env.ACT}}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64


### PR DESCRIPTION
Adds a [github action](https://github.com/features/actions) to automate publishing docker image to dockerhub.

Triggers on these actions and publishes accordingly:

* On commit to `master` branch => published to dockerhub `latest` tag
* On commit to `test` branch => published to dockerhub `test` tag
* On release => published to dockerhub using release `tag`

### To enable

* Go to [repository settings -> secrets and variables -> actions](https://github.com/grokuku/stable-diffusion/settings/secrets/actions)
  * Add repository secrets
    * `DOCKER_USERNAME` - your dockerhub username
    * `DOCKER_PASSWORD` - your dockerhub password
  * Add repository **variables**
    * `DOCKERHUB_IMAGE_NAME` - the full name of the dockerhub image IE `holaflenain/stable-diffusion`
    * `GHCR_IMAGE_NAME` - (Optional) the full name of the GHCR image IE `ghcr.io/grokuku/stable-diffusion`
* Go to [repository settings -> Actions -> General](https://github.com/FoxxMD/multi-scrobbler/settings/actions)
  *  Action permissions -> **Allow all actions...**
  * Workflow permissions -> **Read and write permissions**
  * Save

### Github Packages

If you include the variable `GHCR_IMAGE_NAME` you can also enable hosting images with [github packages](https://github.com/features/packages) with the same tags as dockerhub, using `ghcr.io/grokuku/stable-diffusion`