### PR TITLE
Downgrade Python to 3.10 to fix Fooocus

### DIFF
--- a/06.sh
+++ b/06.sh
@@ -12,7 +12,7 @@ fi
 
 source activate ${SD06_DIR}/env
 conda install -n base conda-libmamba-solver -y
-conda install -c conda-forge git python=3.11 pip --solver=libmamba -y
+conda install -c conda-forge git python=3.10 pip --solver=libmamba -y
 conda install -c nvidia cuda-cudart --solver=libmamba -y
 
 if [ ! -f "$SD06_DIR/parameters.txt" ]; then


### PR DESCRIPTION
- Focus doesn't work with Python 3.11 due to a dependency mismatch: https://github.com/lllyasviel/Fooocus/issues/1413#issuecomment-1856914993
- It seems like 3.10 is the one they require in their readme
- I tested this by overwriting 06.sh in the `holaflenain/stable-diffusion:2.0.2` image and it worked