### PR TITLE
fix(sdnext): Fix embeddings source location

### DIFF
--- a/04.sh
+++ b/04.sh
@@ -71,7 +71,7 @@ sl_folder ${SD04_DIR}/webui/models Stable-diffusion ${BASE_DIR}/models stable-di
 sl_folder ${SD04_DIR}/webui/models hypernetworks ${BASE_DIR}/models hypernetwork
 sl_folder ${SD04_DIR}/webui/models Lora ${BASE_DIR}/models lora
 sl_folder ${SD04_DIR}/webui/models VAE ${BASE_DIR}/models vae
-sl_folder ${SD04_DIR}/webui embeddings ${BASE_DIR}/models embeddings
+sl_folder ${SD04_DIR}/webui/models embeddings ${BASE_DIR}/models embeddings
 sl_folder ${SD04_DIR}/webui/models ESRGAN ${BASE_DIR}/models upscale
 sl_folder ${SD04_DIR}/webui/models Codeformer ${BASE_DIR}/models codeformer
 sl_folder ${SD04_DIR}/webui/models GFPGAN ${BASE_DIR}/models gfpgan


### PR DESCRIPTION
embeddings folder differs compared to stable-diffusion-webui -- in sd.next it is located in models/embeddings instead of top level

https://github.com/vladmandic/automatic/blob/439542d3df3d2d6cefbe2360966a6566bc1de341/modules/shared.py#L385