### PR TITLE
fix(sdnext): Remove invalid arg

### DIFF
--- a/parameters/04.txt
+++ b/parameters/04.txt
@@ -6,4 +6,3 @@
 --insecure
 --medvram
 --allow-code
---no-download


### PR DESCRIPTION
The latest version of SDNext (2024-02-07) removed `--no-download` cli arg. Remove from params to prevent SD from crashing on startup