### PR TITLE
Add t5 and unet folder to shared models folder for ComfyUI

### DIFF
--- a/05.sh
+++ b/05.sh
@@ -71,6 +71,8 @@ sl_folder ${SD05_DIR}/ComfyUI/models upscale_models ${BASE_DIR}/models upscale
 sl_folder ${SD05_DIR}/ComfyUI/models clip_vision ${BASE_DIR}/models clip_vision
 sl_folder ${SD05_DIR}/ComfyUI/models clip ${BASE_DIR}/models clip
 sl_folder ${SD05_DIR}/ComfyUI/models controlnet ${BASE_DIR}/models controlnet
+sl_folder ${SD05_DIR}/ComfyUI/models t5 ${BASE_DIR}/models t5
+sl_folder ${SD05_DIR}/ComfyUI/models unet ${BASE_DIR}/models unet
 
 
 


### PR DESCRIPTION
Some Models like the new Flux model recommend putting the safetensors in the Unet folder, instead of "stable diffusion". Same for t5 folder.

Also, i would recommend changing the "Stable Diffusion" folder back to "checkpoints", as there are more models/base models other then stable diffusion now, and the naming "Stable Diffusion" is confusing imo