### PR TITLE
Improving permissions management / startup time on some systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN mkdir -p ${BASE_DIR}\temp ${SD_INSTALL_DIR} ${BASE_DIR}/outputs
 
 ADD parameters/* ${SD_INSTALL_DIR}/parameters/
 
+RUN groupmod -g 1000 abc && \
+    usermod -u 1000 abc
+
 COPY --chown=abc:abc *.sh ./
 
 RUN chmod +x /entry.sh
@@ -46,7 +49,7 @@ RUN cd /tmp && \
     bash Miniconda3-latest-Linux-x86_64.sh -b && \
     rm Miniconda3-latest-Linux-x86_64.sh && \
     chown -R abc:abc /root && \
-    chown -R abc:abc ${SD_INSTALL_DIR}
-
+    chown -R abc:abc ${SD_INSTALL_DIR} && \
+    chown -R abc:abc /home/abc
 
 EXPOSE 9000/tcp

--- a/docker/root/etc/s6-overlay/s6-rc.d/init-chown/run
+++ b/docker/root/etc/s6-overlay/s6-rc.d/init-chown/run
@@ -3,8 +3,8 @@
 #echo "-------------------------------------"
 # permissions
 #echo "chown'ing home directory to ensure correct permissions."
-find /home/abc -type d \( ! -user abc -o ! -group abc \) -exec chown -R {} \;
-find /home/abc -type f \( ! -user abc -o ! -group abc \) -exec chown {} \;
+find /home/abc -type d \( ! -user abc -o ! -group abc \) -exec chown -R abc:abc {} \;
+find /home/abc -type f \( ! -user abc -o ! -group abc \) -exec chown abc:abc {} \;
 #echo "Done!"
 #echo -e "-------------------------------------\n"
 

--- a/docker/root/etc/s6-overlay/s6-rc.d/init-chown/run
+++ b/docker/root/etc/s6-overlay/s6-rc.d/init-chown/run
@@ -3,7 +3,8 @@
 #echo "-------------------------------------"
 # permissions
 #echo "chown'ing home directory to ensure correct permissions."
-chown -R abc:abc /home/abc
+find /home/abc -type d \( ! -user abc -o ! -group abc \) -exec chown -R {} \;
+find /home/abc -type f \( ! -user abc -o ! -group abc \) -exec chown {} \;
 #echo "Done!"
 #echo -e "-------------------------------------\n"
 


### PR DESCRIPTION
To ensure correct permissions, a recursive `chown` was made on `/home/abc` at each launch (in  `/docker/root/etc/s6-overlay/s6/rc.d/init-chown/run`).
On some (file)systems, it could be quite long because there are many (small) files. (I'm note sure why, but in an lxc container on one of my servers it takes 2 minutes, whereas on another, more classic system, it is almost instantaneous).

I propose:

1) a different way to change permissions on launch in case they are not correct, using `find` to detect dirs/files to change instead on `chown`ing all the directory. It seems more efficient.

2) furthermore, since the default values ​​of `PGID` and `PUID` environment variables are 1000 in docker-compose, and most users will not change them, I propose to modify the Ids of the user and group "abc" (which are 911 by default in the base image) directly when building the image, to limit the number of changes to be made after launching the container in the majority of use cases

3) adding a `chown` on /home/abc after the installation of Miniconda

This fixes the performance issue I've been seeing, and I think it might help prevent future complications with file permissions.