### PR TITLE
Version Specific installs in Dockerfile

### DIFF
--- a/02.forge.sh
+++ b/02.forge.sh
@@ -40,7 +40,7 @@ fi
 pip install --upgrade pip
 
 if [ -f ${SD02_DIR}/requirements.txt ]; then
-    pip install -r ${SD02_DIR}/requirements.txt
+    pip install -r ${SD02_DIR}/requirements_versions.txt
 fi
 
 # Merge Models, vae, lora, and hypernetworks, and outputs

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN pip install torch torchvision packaging
 # Configurer gcc et g++
 ENV CC=/usr/bin/gcc-12
 ENV CXX=/usr/bin/g++-12
-ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 8.9 9.0 9.0a"
+ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 8.9 9.0 9.0a 10.0 10.0f 10.0a 10.1 10.1f 10.1a 10.3 10.3f 10.3a 12.0 12.0f 12.0a 12.1 12.1f 12.1a"
 ENV CPLUS_INCLUDE_PATH=/usr/local/cuda/include:$CPLUS_INCLUDE_PATH
 ENV LIBRARY_PATH=/usr/local/cuda/lib64:$LIBRARY_PATH
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN pip install cython==0.29.37
 # Configurer gcc et g++
 ENV CC=/usr/bin/gcc-12
 ENV CXX=/usr/bin/g++-12
-ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 8.9 9.0 9.0a
+ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 8.9 9.0 9.0a"
 ENV CPLUS_INCLUDE_PATH=/usr/local/cuda/include:$CPLUS_INCLUDE_PATH
 ENV LIBRARY_PATH=/usr/local/cuda/lib64:$LIBRARY_PATH
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN pip install cython==0.29.37
 # Configurer gcc et g++
 ENV CC=/usr/bin/gcc-12
 ENV CXX=/usr/bin/g++-12
-ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 8.9 9.0 9.0a 10.0 10.0f 10.0a 10.1 10.1f 10.1a 10.3 10.3f 10.3a 12.0 12.0f 12.0a 12.1 12.1f 12.1a"
+ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 8.9 9.0 9.0a
 ENV CPLUS_INCLUDE_PATH=/usr/local/cuda/include:$CPLUS_INCLUDE_PATH
 ENV LIBRARY_PATH=/usr/local/cuda/lib64:$LIBRARY_PATH
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
@@ -91,7 +91,7 @@ ENV BASE_DIR=/config \
     XDG_CACHE_HOME=/config/temp
 ENV CC=/usr/bin/gcc-12
 ENV CXX=/usr/bin/g++-12
-ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 8.9 9.0 9.0a 10.0 10.0f 10.0a 10.1 10.1f 10.1a 10.3 10.3f 10.3a 12.0 12.0f 12.0a 12.1 12.1f 12.1a"
+ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 8.9 9.0 9.0a"
 
 RUN apt-get update -q && \
     apt-get install -y -q=2 curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get install -y -q=2 software-properties-common && \
     git \
     gcc-12 g++-12
 
-RUN pip install torch torchvision packaging
+RUN pip install torch==2.6.0 torchvision packaging
 
 # Configurer gcc et g++
 ENV CC=/usr/bin/gcc-12

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get install -y -q=2 software-properties-common && \
     gcc-12 g++-12
 
 RUN pip install torch==2.6.0 torchvision packaging
+RUN pip install cython==0.29.37
 
 # Configurer gcc et g++
 ENV CC=/usr/bin/gcc-12

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ ENV BASE_DIR=/config \
     XDG_CACHE_HOME=/config/temp
 ENV CC=/usr/bin/gcc-12
 ENV CXX=/usr/bin/g++-12
-ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 8.9 9.0 9.0a"
+ENV TORCH_CUDA_ARCH_LIST="8.0 8.6 8.7 8.9 9.0 9.0a 10.0 10.0f 10.0a 10.1 10.1f 10.1a 10.3 10.3f 10.3a 12.0 12.0f 12.0a 12.1 12.1f 12.1a"
 
 RUN apt-get update -q && \
     apt-get install -y -q=2 curl \


### PR DESCRIPTION
While it's better to regularly pull the most up-to-date versions of tools, the docker image is currently unusable, as Kaolin is not updated to support Torch 2.7.0 and Cython's change in their naming scheme has fucked the ability of Kaolin to install. So this pull request forces Torch 2.6.0 and Cython 0.29.37 until Kaonin updates to Torch 2.7.0 and Cython 3.0.*.